### PR TITLE
Feat/goals setter and getter

### DIFF
--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -10,7 +10,7 @@
    (let* (
           ($andLink (AND_LINK ($context $action)))
           ($_ (add-atom &self $andLink))
-          )
+        )
         $andLink
      )
 )
@@ -36,7 +36,7 @@
      )
 )
 
-(: existsIn Grounded Atom Atom)
+(: existsIn Grounded Atom Bool)
 (= (existsIn $space $atom)
    ( let $res (collapse (get-type-space $space $atom)) (not (== (%Undefined%) $res)) )
 )
@@ -117,4 +117,56 @@
     )
   )
 )
+
+;the function accepts an optional third argument,
+;dgv(desiredGoalValue), if () is passed then a default value of 1
+;is used
+
+;(: x (Goal $value $dgv))
+(: addGoalHelper (-> Symbol Number Number Atom))
+(= (addGoalHelper $name $value $dgv)
+   (if (and (isGvValid $value) (isGvValid $dgv)) 
+      (if (not (existsIn &self $name))
+          (let () 
+              (add-atom &self (: $name (Goal $value $dgv))) 
+              $name
+          )
+          (Goal With Id $name Already Exists)
+        )
+      (Invalid goal/dgv Value) 
+    )
+)
+
+(: isGvValid (-> Number Bool))
+(= (isGvValid $value)
+   (and (>= $value 0.0) (<= $value 1.0))
+   )
+
+(: addGoal (-> Symbol Number Atom Atom))
+(= (addGoal $name $value $dgv)
+   (if (== () $dgv) 
+      (addGoalHelper $name $value 1.0) 
+      (addGoalHelper $name $value $dgv)
+    )
+   )
+
+(: setGv (-> Symbol Number (->)))
+(= (setGv $goal $value)
+   (if (not (existsIn &self $goal))
+          (Invalid Goal Id)
+          (let (Goal $oldGv $oldDgv) (get-type $goal) 
+              (update-atom &self (: $goal (Goal $oldGv $oldDgv)) (: $goal (Goal $value $oldDgv)))
+              )
+    )
+   )
+
+(: setDgv (-> Symbol Number (->)))
+(= (setDgv $goal $value)
+   (if (not (existsIn &self $goal))
+          (Invalid Goal Id)
+          (let (Goal $oldGv $oldDgv) (get-type $goal) 
+              (update-atom &self (: $goal (Goal $oldGv $oldDgv)) (: $goal (Goal $oldGv $value)))
+              )
+    )
+   )
 

--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -120,7 +120,7 @@
 
 
 ;(: x (Goal $value $dgv))
-(: addGoalHelper (-> Symbol Number Number Atom))
+(: addGoalHelper (-> Expression Number Number Atom))
 (= (addGoalHelper $name $value $dgv)
    (if (and (isGvValid $value) (isGvValid $dgv)) 
       (if (not (existsIn &self $name))
@@ -142,7 +142,7 @@
 ;This function accepts an optional third argument,
 ;dgv(desiredGoalValue), if () is passed then a default value of 1.0 is used.
 ;Returns the symbol representing the added goal.
-(: addGoal (-> Symbol Number Atom Atom))
+(: addGoal (-> Expression Number Atom Atom))
 (= (addGoal $name $value $dgv)
    (if (== () $dgv) 
       (addGoalHelper $name $value 1.0) 

--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -141,7 +141,7 @@
 
 ;This function accepts an optional third argument,
 ;dgv(desiredGoalValue), if () is passed then a default value of 1.0 is used.
-;returns the symbol representing the added goal
+;Returns the symbol representing the added goal.
 (: addGoal (-> Symbol Number Atom Atom))
 (= (addGoal $name $value $dgv)
    (if (== () $dgv) 

--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -120,7 +120,7 @@
 
 
 ;(: x (Goal $value $dgv))
-(: addGoalHelper (-> Expression Number Number Atom))
+(: addGoalHelper (-> Symbol Number Number Atom))
 (= (addGoalHelper $name $value $dgv)
    (if (and (isGvValid $value) (isGvValid $dgv)) 
       (if (not (existsIn &self $name))
@@ -142,7 +142,7 @@
 ;This function accepts an optional third argument,
 ;dgv(desiredGoalValue), if () is passed then a default value of 1.0 is used.
 ;Returns the symbol representing the added goal.
-(: addGoal (-> Expression Number Atom Atom))
+(: addGoal (-> Symbol Number Atom Atom))
 (= (addGoal $name $value $dgv)
    (if (== () $dgv) 
       (addGoalHelper $name $value 1.0) 

--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -118,9 +118,6 @@
   )
 )
 
-;the function accepts an optional third argument,
-;dgv(desiredGoalValue), if () is passed then a default value of 1
-;is used
 
 ;(: x (Goal $value $dgv))
 (: addGoalHelper (-> Symbol Number Number Atom))
@@ -142,6 +139,9 @@
    (and (>= $value 0.0) (<= $value 1.0))
    )
 
+;This function accepts an optional third argument,
+;dgv(desiredGoalValue), if () is passed then a default value of 1.0 is used.
+;returns the symbol representing the added goal
 (: addGoal (-> Symbol Number Atom Atom))
 (= (addGoal $name $value $dgv)
    (if (== () $dgv) 

--- a/main/rules/tests/rule-test.metta
+++ b/main/rules/tests/rule-test.metta
@@ -30,10 +30,10 @@
 
 !(assertEqual (existsIn &psiRules x) True)
 
-!(assertEqual (addGoal (reduce-hunger) 1 0) (reduce-hunger))
-!(assertEqual (addGoal (reduce-hunger) 1 1) (Goal With Id (reduce-hunger) Already Exists))
-!(assertEqual (addGoal (reduce-hunger) 10 1) (Invalid goal/dgv Value))
-!(assertEqual (addGoal (reduce-hunger) 1 10) (Invalid goal/dgv Value))
+!(assertEqual (addGoal reduceHunger 1 0) reduceHunger)
+!(assertEqual (addGoal reduceHunger 1 1) (Goal With Id reduceHunger Already Exists))
+!(assertEqual (addGoal reduceHunger 10 1) (Invalid goal/dgv Value))
+!(assertEqual (addGoal reduceHunger 1 10) (Invalid goal/dgv Value))
 !(assertEqual (addGoal run 1 ()) run)
 
 !(setGv run 0.5)

--- a/main/rules/tests/rule-test.metta
+++ b/main/rules/tests/rule-test.metta
@@ -31,7 +31,7 @@
 !(assertEqual (existsIn &psiRules x) True)
 
 !(assertEqual (addGoal (reduce-hunger) 1 0) (reduce-hunger))
-!(assertEqual (addGoal (reduce-hunger) 1 1) (Goal With Id eat Already Exists))
+!(assertEqual (addGoal (reduce-hunger) 1 1) (Goal With Id (reduce-hunger) Already Exists))
 !(assertEqual (addGoal (reduce-hunger) 10 1) (Invalid goal/dgv Value))
 !(assertEqual (addGoal (reduce-hunger) 1 10) (Invalid goal/dgv Value))
 !(assertEqual (addGoal run 1 ()) run)

--- a/main/rules/tests/rule-test.metta
+++ b/main/rules/tests/rule-test.metta
@@ -29,3 +29,14 @@
 !(assertEqual (existsIn &psiRules rule1) False)
 
 !(assertEqual (existsIn &psiRules x) True)
+
+!(assertEqual (addGoal (reduce-hunger) 1 0) (reduce-hunger))
+!(assertEqual (addGoal (reduce-hunger) 1 1) (Goal With Id eat Already Exists))
+!(assertEqual (addGoal (reduce-hunger) 10 1) (Invalid goal/dgv Value))
+!(assertEqual (addGoal (reduce-hunger) 1 10) (Invalid goal/dgv Value))
+!(assertEqual (addGoal run 1 ()) run)
+
+!(setGv run 0.5)
+!(setDgv run 0.1)
+
+!(assertEqual (get-type run) (Goal 0.5 0.1))


### PR DESCRIPTION
additions made in this PR:

- I have made a tuple of `(Goal $gv $dgv)` to be assigned as a type to a Symbol representing a goal.  So, a goal in our system looks like `(: someGoal (Goal $gv $dgv))`. We can simply use `get-type` to query a goals values.
- I have made the assumption that goals are unique and there can only exist a one-to-one association between a goal and its value tuple.