### PR TITLE
feat: add demand-updater with test cases

### DIFF
--- a/main/mind-agents/demand-updater/demand-updaters.metta
+++ b/main/mind-agents/demand-updater/demand-updaters.metta
@@ -2,13 +2,14 @@
 
 ; util functions 
 !(bind! exp (py-atom numpy.exp))
+!(bind! rand-float (py-atom numpy.random.rand))
 
 
 ; fuzzy new 
 ; ti is the latest time stamp of observing object i and 
 ; ts is the current time stamp of the virtual world.
 (= (fuzzy-new $ti $ts)
-    (/ 2 (+ 1 (exp (* 0.002 (- $ts $ti)))))
+    (let $x (exp (* 0.002 (- $ts $ti))) (/ 2 (+ 1 $x)))
 )
 
 
@@ -20,7 +21,7 @@
     (/ 1 (+ 1 (* 0.00015 (- $di $dmax))) )
 )
 
-; summation of fuzzy near 
+
 (= (sum-fuzzy-near $lst $d-max)
     (if (== $lst ())               
         0
@@ -51,7 +52,6 @@
 )
 
 
-
 ; Certainity demand updater
 (: CertaintyDemandUpdater (-> Expression Number  Number))
 (= (CertaintyDemandUpdater $lst  $ts)
@@ -59,9 +59,11 @@
     (let* (
             ($summation (sum-fuzzy-new $lst $ts ))
             ($object-num (size-atom $lst))
+            ($rand (rand-float))
+            ($x (exp (* -0.05  $object-num)))
         )
-    (/ (+ $summation (random-float 0 1))
-        (+ 1 (* (exp (* -0.05  $object-num)) (+ 1  $object-num)))))
+    (/ (+ $summation $rand)
+        (+ 1 (* $x (+ 1  $object-num)))))
         
 )
 
@@ -72,12 +74,13 @@
     (let* (
             ($summation (sum-fuzzy-near $lst $d-max ))
             ($friend-num (size-atom $lst))
+            ($rand (rand-float))
+            ($x (exp (* -0.1  $friend-num))) 
         )
-    (/ (+ $summation (random-float 0 1))
-        (+ 1 (* (exp (* -0.1  $friend-num)) (+ 1  $friend-num))))
+    (/ (+ $summation $rand)
+        (+ 1 (* $x (+ 1  $friend-num))))
         
 ))
-
 
 
 ; Competence Demand Updater 
@@ -85,4 +88,3 @@
 (= (CompetenceDemandUpdater $plan-done-number  $plan-failed-number)
     (/ $plan-done-number  (+ $plan-done-number (pow-math $plan-failed-number 1.5))  )
 )
-

--- a/main/mind-agents/demand-updater/demand-updaters.metta
+++ b/main/mind-agents/demand-updater/demand-updaters.metta
@@ -1,0 +1,98 @@
+; Demand Updater 
+; Based on OpenPsi ben paper 
+
+; util functions 
+!(bind! exp (py-atom numpy.exp))
+; fuzzy new 
+; ti is the latest time stamp of observing object i and 
+; ts is the current time stamp of the virtual world.
+(= (fuzzy-new $ti $ts)
+    (/ 2 (+ 1 (exp (* 0.002 (- $ts $ti)))))
+)
+
+
+; fuzzy near 
+; function used to compute affilation demand level
+; di - denotes the distance between friend i and the avatar itself
+; dmax - is a distance threshold to decrease the impact of friends far away.
+(=(fuzzy-near $di $dmax)
+    (/ 1 (+ 1 (* 0.00015 (- $di $dmax))) )
+)
+
+; length of expression 
+(= (length-exp $y)
+    (if (== $y ()) 0
+        (let $tail (cdr-atom $y) 
+            ( + 1 (length-exp $tail)))
+    )
+)
+
+; summation of fuzzy near 
+(= (sum-fuzzy-near $lst $d-max)
+
+    (if (== $lst ())               
+        0
+        (let*(
+                ($a (car-atom $lst))
+                ($c (cdr-atom $lst))
+                ($b (fuzzy-near $a $d-max))
+                ($d (sum-fuzzy-near $c $d-max))
+            )
+             ( + $b $d)
+           )
+    ) 
+)
+
+
+; summation of fuzzy new 
+(= (sum-fuzzy-new $lst $d-max)
+
+    (if (== $lst ())               
+        0
+        (let*(
+                ($a (car-atom $lst))
+                ($c (cdr-atom $lst))
+                ($b (fuzzy-new $a $d-max))
+                ($d (sum-fuzzy-new $c $d-max))
+            )
+             ( + $b $d)
+           )
+    ) 
+)
+
+
+
+; Certainity demand updater
+(: CertaintyDemandUpdater (-> Expression Number  Number))
+(= (CertaintyDemandUpdater $lst  $ts)
+
+    (let* (
+            ($summation (sum-fuzzy-new $lst $ts ))
+            ($object-num (length-exp $lst))
+        )
+    (/ (+ $summation (random-float 0 1))
+        (+ 1 (* (exp (* -0.05  $object-num)) (+ 1  $object-num)))))
+        
+)
+
+
+; Affiliation Demand Updater 
+(: AffiliationDemandUpdater (-> Expression  Number Number))
+(= (AffiliationDemandUpdater  $lst  $d-max)
+    (let* (
+            ($summation (sum-fuzzy-near $lst $d-max ))
+            ($friend-num (length-exp $lst))
+        )
+    (/ (+ $summation (random-float 0 1))
+        (+ 1 (* (exp (* -0.1  $friend-num)) (+ 1  $friend-num))))
+        
+))
+
+
+
+; Competence Demand Updater 
+(: CompetenceDemandUpdater (-> Number Number  Number))
+(= (CompetenceDemandUpdater $plan-done-number  $plan-failed-number)
+    (/ $plan-done-number  (+ $plan-done-number (pow-math $plan-failed-number 1.5))  )
+)
+

--- a/main/mind-agents/demand-updater/demand-updaters.metta
+++ b/main/mind-agents/demand-updater/demand-updaters.metta
@@ -5,7 +5,8 @@
 !(bind! rand-float (py-atom numpy.random.rand))
 
 
-; fuzzy new 
+; fuzzy new
+; function used to compute certainty demand level
 ; ti is the latest time stamp of observing object i and 
 ; ts is the current time stamp of the virtual world.
 (= (fuzzy-new $ti $ts)
@@ -21,36 +22,21 @@
     (/ 1 (+ 1 (* 0.00015 (- $di $dmax))) )
 )
 
-
+; summation of fuzzy near 
 (= (sum-fuzzy-near $lst $d-max)
-    (if (== $lst ())               
-        0
-        (let*(
-                ($a (car-atom $lst))
-                ($c (cdr-atom $lst))
-                ($b (fuzzy-near $a $d-max))
-                ($d (sum-fuzzy-near $c $d-max))
-            )
-             ( + $b $d)
-           )
-    ) 
+
+    (let $fnear (collapse(fuzzy-near (superpose $lst) $d-max)) 
+        (foldl-atom $fnear 0 $acc $x (+ $acc $x))
+    )
 )
 
 ; summation of fuzzy new 
-(= (sum-fuzzy-new $lst $d-max)
-    (if (== $lst ())               
-        0
-        (let*(
-                ($a (car-atom $lst))
-                ($c (cdr-atom $lst))
-                ($b (fuzzy-new $a $d-max))
-                ($d (sum-fuzzy-new $c $d-max))
-            )
-             ( + $b $d)
-           )
-    ) 
-)
+(= (sum-fuzzy-new $lst $ts)
 
+    (let $fnew (collapse(fuzzy-new (superpose $lst) $ts)) 
+        (foldl-atom $fnew 0 $acc $x (+ $acc $x))
+    )
+)
 
 ; Certainity demand updater
 (: CertaintyDemandUpdater (-> Expression Number  Number))

--- a/main/mind-agents/demand-updater/demand-updaters.metta
+++ b/main/mind-agents/demand-updater/demand-updaters.metta
@@ -1,8 +1,9 @@
-; Demand Updater 
-; Based on OpenPsi ben paper 
+; Demand Updater - Based on OpenPsi ben paper 
 
 ; util functions 
 !(bind! exp (py-atom numpy.exp))
+
+
 ; fuzzy new 
 ; ti is the latest time stamp of observing object i and 
 ; ts is the current time stamp of the virtual world.
@@ -19,17 +20,8 @@
     (/ 1 (+ 1 (* 0.00015 (- $di $dmax))) )
 )
 
-; length of expression 
-(= (length-exp $y)
-    (if (== $y ()) 0
-        (let $tail (cdr-atom $y) 
-            ( + 1 (length-exp $tail)))
-    )
-)
-
 ; summation of fuzzy near 
 (= (sum-fuzzy-near $lst $d-max)
-
     (if (== $lst ())               
         0
         (let*(
@@ -43,10 +35,8 @@
     ) 
 )
 
-
 ; summation of fuzzy new 
 (= (sum-fuzzy-new $lst $d-max)
-
     (if (== $lst ())               
         0
         (let*(
@@ -68,7 +58,7 @@
 
     (let* (
             ($summation (sum-fuzzy-new $lst $ts ))
-            ($object-num (length-exp $lst))
+            ($object-num (size-atom $lst))
         )
     (/ (+ $summation (random-float 0 1))
         (+ 1 (* (exp (* -0.05  $object-num)) (+ 1  $object-num)))))
@@ -81,7 +71,7 @@
 (= (AffiliationDemandUpdater  $lst  $d-max)
     (let* (
             ($summation (sum-fuzzy-near $lst $d-max ))
-            ($friend-num (length-exp $lst))
+            ($friend-num (size-atom $lst))
         )
     (/ (+ $summation (random-float 0 1))
         (+ 1 (* (exp (* -0.1  $friend-num)) (+ 1  $friend-num))))

--- a/main/mind-agents/demand-updater/tests/demand-updaters-test.metta
+++ b/main/mind-agents/demand-updater/tests/demand-updaters-test.metta
@@ -1,0 +1,9 @@
+!(register-module! ../../../../../hyperon-openpsi)
+!(import! &self hyperon-openpsi:main:mind-agents:demand-updater:demand-updaters)
+
+; due to the randomness of CertaintyDemandUpdater and AffiliationDemandUpdater we have range of return values 
+!(assertEqual (and (> (CertaintyDemandUpdater  (10 20 30  40 50) 25) 0.80) (< (CertaintyDemandUpdater  (10 20 30  40 50) 25) 1.07)) True)
+!(assertEqual (and (> (AffiliationDemandUpdater  (10 20 30) 25) 0.74) (< (AffiliationDemandUpdater  (10 20 30) 25) 1.02)) True)
+!(assertEqual (CompetenceDemandUpdater 12 20 ) 0.1182933591140401)
+!(assertEqual (CompetenceDemandUpdater 12 4) 0.6)
+

--- a/psi-utilities/psi_utils.metta
+++ b/psi-utilities/psi_utils.metta
@@ -5,12 +5,14 @@
 
 
 (= (fuzzy_within $x $min_val $max_val $a)
-    (if (< $x $max_val)
-                (fuzzy_equal $x $min_val $a)
-                (if (> $x $max_val)
-                        (+ 0.999 (* uniRand 0.001))
-                        (+ 0.99 (* uniRand 0.01))
+    (if (< $x $min_val)
+                (fuzzy_equal $x $min_val $a) ; x < min value
+                (let $rand (uniRand) 
+                    (if (> $x $max_val) 
+                        (+ 0.999 (* $rand 0.001)) ; x > max value
+                        (+ 0.99 (* $rand 0.01)) ; min value < x < max value
 
+                    )
                 )
         )
 )
@@ -129,6 +131,7 @@
 !(UniformRandom : uniRand)
 !(FuzzyEqual (fuzzy_equal 4 2.0 3))
 !(FuzzyWithin (fuzzy_within 2.0 1.0 3.0 3))
+!(FuzzyWithin (fuzzy_within 4.0 1.0 3.0 3))
+!(FuzzyWithin (fuzzy_within 0.5 1.0 3.0 3))
 !(FuzzyLessThan (fuzzy_less_than 2.0 3.0 3))
-
 !(FuzzyGreaterThan (fuzzy_greater_than 2.0 3.0 3))


### PR DESCRIPTION

-  Add demand updater mind agent based on OpenPsi Ben paper 
- Include Certainty, Affiliation and Competence demands
- Adds test cases for the demand updater.
