### PR TITLE
Refactor rule related functions & add getImplication 

### DIFF
--- a/main/mind-agents/action-planner/tests/action-planner-v2-test.metta
+++ b/main/mind-agents/action-planner/tests/action-planner-v2-test.metta
@@ -6,15 +6,18 @@
 !(import! &self hyperon-openpsi:main:rules:rule)
 !(import! &self utilities-module:utils)
 
-!(addGoal (S1 is off) 0.0 () &self)
-!(addGoal (S2 is off) 0.0 () &self)
-!(addGoal (S3 is off) 0.0 () &self)
-!(addGoal (S4 is off) 0.0 () &self)
 
-!(addGoal (S1 is on) 0.5 1 &self)
-!(addGoal (S2 is on) 0.75 1 &self)
-!(addGoal (S3 is on) 1.0 1.0 &self)
-!(addGoal (S4 is on) 0.0 () &self)
+!(bind! &r (new-space)) 
+
+!(addGoal (S1 is off) 0.0 () &r)
+!(addGoal (S2 is off) 0.0 () &r)
+!(addGoal (S3 is off) 0.0 () &r)
+!(addGoal (S4 is off) 0.0 () &r)
+
+!(addGoal (S1 is on) 0.5 1 &r)
+!(addGoal (S2 is on) 0.75 1 &r)
+!(addGoal (S3 is on) 1.0 1.0 &r)
+!(addGoal (S4 is on) 0.0 () &r)
 
 ;First test case
                 ;Test Description:
@@ -25,15 +28,15 @@
 ; - S2 can only be turned on if S1 is already on.
 ; - S3 can only be turned on if S2 is already on.
 
-!(addRule r1 ((S1 is off)) (Turn on S1) (S1 is on) (TTV 0 (STV 1.0 1.0)))
-!(addRule r2 ((S1 is on)) (Turn on S2) (S2 is on) (TTV 0 (STV 1.0 1.0)))
-!(addRule r3 ((S2 is on)) (Turn on S3) (S3 is on) (TTV 0 (STV 1.0 1.0)))
-!(addRule r3' ((S3 is off)) (Turn on S3) (S3 is on) (TTV 0 (STV 1.0 1.0)))
-!(addRule r4 ((S3 is on)) (Turn on S4) (S4 is on) (TTV 0 (STV 1.0 1.0)))
-!(addRule r4' ((S4 is off)) (Turn on S4) (S4 is on) (TTV 0 (STV 1.0 1.0)))
-;!(addRule r5 ((S1 is on)) (Turn off S1) (S1 is off) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r1 ((S1 is off)) (Turn on S1) (S1 is on) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r2 ((S1 is on)) (Turn on S2) (S2 is on) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r3 ((S2 is on)) (Turn on S3) (S3 is on) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r3' ((S3 is off)) (Turn on S3) (S3 is on) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r4 ((S3 is on)) (Turn on S4) (S4 is on) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r4' ((S4 is off)) (Turn on S4) (S4 is on) (TTV 0 (STV 1.0 1.0)))
+;!(addRule &r r5 ((S1 is on)) (Turn off S1) (S1 is off) (TTV 0 (STV 1.0 1.0)))
 
-!(assertEqual (hillClimbingPlanner (S1 is off) (S3 is on) (TestedActions) () &self) ((Turn on S3) (Turn on S2) (Turn on S1)))
+!(assertEqual (hillClimbingPlanner (S1 is off) (S3 is on) (TestedActions) () &r) ((Turn on S3) (Turn on S2) (Turn on S1)))
 
 
 ;Second Test Case
@@ -46,33 +49,33 @@
 ; - P3 can only have the ball if P2  kick it to P3.
 ; - P4 can have the ball if P3 is kicked to it or by giving to it.
 ; - Goal is scored only if P4 kicked the ball to the Goal 
-!(addGoal (P1 doesn't have the ball) 0.0 () &self)
-!(addGoal (P2 doesn't have the ball) 0.0 () &self)
-!(addGoal (P3 doesn't have the ball) 0.0 () &self)
-!(addGoal (P4 doesn't have the ball) 0.0 () &self)
+!(addGoal (P1 doesn't have the ball) 0.0 () &r)
+!(addGoal (P2 doesn't have the ball) 0.0 () &r)
+!(addGoal (P3 doesn't have the ball) 0.0 () &r)
+!(addGoal (P4 doesn't have the ball) 0.0 () &r)
 
-!(addGoal (P1 has the ball) 0.1 1.0 &self)
-!(addGoal (P2 has the ball) 0.4 1.0 &self)
-!(addGoal (P3 has the ball) 0.7 1.0 &self)
-!(addGoal (P4 has the ball) 0.8 1.0 &self)
-!(addGoal (Goal Scored) 1.0 1.0 &self)
-
-
-!(addRule rr1' ((P1 doesn't have the ball)) (Give ball to P1) (P1 has the ball) (TTV 0 (STV 1.0 1.0)))
-!(addRule rr1 ((P1 has the ball)) (P1 Kick to P2) (P2 has the ball) (TTV 0 (STV 1.0 1.0)))
-!(addRule rr2' ((P2 doesn't have the ball)) (Give ball to P2) (P2 has the ball) (TTV 0 (STV 1.0 1.0)))
-!(addRule rr2 ((P2 has the ball)) (P2 Kick to P3) (P3 has the ball) (TTV 0 (STV 1.0 1.0)))
-!(addRule rr3 ((P3 has the ball)) (P3 Kick to P4) (P4 has the ball) (TTV 0 (STV 1.0 1.0)))
-!(addRule rr4' ((P4 doesn't have the ball)) (Give ball to P4) (P4 has the ball) (TTV 0 (STV 1.0 1.0)))
-!(addRule rr4 ((P4 has the ball)) (P4 Kick to Goal) (Goal Scored) (TTV 0 (STV 1.0 1.0)))
+!(addGoal (P1 has the ball) 0.1 1.0 &r)
+!(addGoal (P2 has the ball) 0.4 1.0 &r)
+!(addGoal (P3 has the ball) 0.7 1.0 &r)
+!(addGoal (P4 has the ball) 0.8 1.0 &r)
+!(addGoal (Goal Scored) 1.0 1.0 &r)
 
 
- !(assertEqual (hillClimbingPlanner (P1 has the ball) (P3 has the ball) (TestedActions) () &self) ((P2 Kick to P3) (P1 Kick to P2)))
- !(assertEqual (hillClimbingPlanner (P1 has the ball) (Goal Scored) (TestedActions) () &self) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3) (P1 Kick to P2)) )
- !(assertEqual (hillClimbingPlanner (P2 has the ball) (Goal Scored) (TestedActions) () &self) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3)))
- !(assertEqual (hillClimbingPlanner (P2 has the ball) (P4 has the ball) (TestedActions) () &self) ((P3 Kick to P4) (P2 Kick to P3)))
- !(assertEqual (hillClimbingPlanner (P1 doesn't have the ball) (Goal Scored) (TestedActions) () &self) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3) (P1 Kick to P2) (Give ball to P1)))
- !(assertEqual (hillClimbingPlanner (P2 doesn't have the ball) (Goal Scored) (TestedActions) () &self) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3) (Give ball to P2)))
- !(assertEqual (hillClimbingPlanner (P3 doesn't have the ball) (Goal Scored) (TestedActions) () &self) ()) ; no actions taken since there is no rule to apply
- !(assertEqual (hillClimbingPlanner (P4 doesn't have the ball) (Goal Scored) (TestedActions) () &self) ((P4 Kick to Goal) (Give ball to P4)))
- !(assertEqual (hillClimbingPlanner (P4 has the ball) (P1 has the ball) (TestedActions) () &self) ()) ; no rules to go backward 
+!(addRule &r rr1' ((P1 doesn't have the ball)) (Give ball to P1) (P1 has the ball) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r rr1 ((P1 has the ball)) (P1 Kick to P2) (P2 has the ball) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r rr2' ((P2 doesn't have the ball)) (Give ball to P2) (P2 has the ball) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r rr2 ((P2 has the ball)) (P2 Kick to P3) (P3 has the ball) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r rr3 ((P3 has the ball)) (P3 Kick to P4) (P4 has the ball) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r rr4' ((P4 doesn't have the ball)) (Give ball to P4) (P4 has the ball) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r rr4 ((P4 has the ball)) (P4 Kick to Goal) (Goal Scored) (TTV 0 (STV 1.0 1.0)))
+
+
+ !(assertEqual (hillClimbingPlanner (P1 has the ball) (P3 has the ball) (TestedActions) () &r) ((P2 Kick to P3) (P1 Kick to P2)))
+ !(assertEqual (hillClimbingPlanner (P1 has the ball) (Goal Scored) (TestedActions) () &r) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3) (P1 Kick to P2)) )
+ !(assertEqual (hillClimbingPlanner (P2 has the ball) (Goal Scored) (TestedActions) () &r) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3)))
+ !(assertEqual (hillClimbingPlanner (P2 has the ball) (P4 has the ball) (TestedActions) () &r) ((P3 Kick to P4) (P2 Kick to P3)))
+ !(assertEqual (hillClimbingPlanner (P1 doesn't have the ball) (Goal Scored) (TestedActions) () &r) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3) (P1 Kick to P2) (Give ball to P1)))
+ !(assertEqual (hillClimbingPlanner (P2 doesn't have the ball) (Goal Scored) (TestedActions) () &r) ((P4 Kick to Goal) (P3 Kick to P4) (P2 Kick to P3) (Give ball to P2)))
+ !(assertEqual (hillClimbingPlanner (P3 doesn't have the ball) (Goal Scored) (TestedActions) () &r) ()) ; no actions taken since there is no rule to apply
+ !(assertEqual (hillClimbingPlanner (P4 doesn't have the ball) (Goal Scored) (TestedActions) () &r) ((P4 Kick to Goal) (Give ball to P4)))
+ !(assertEqual (hillClimbingPlanner (P4 has the ball) (P1 has the ball) (TestedActions) () &r) ()) ; no rules to go backward 

--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -127,6 +127,19 @@
   )
 )
 
+(: getImplication  (-> Symbol Grounded Expression))
+(= (getImplication $rule $space)
+   (
+    case (getRuleType $rule $space) 
+      (
+        (((TTV $timestamp $stv) (IMPLICATION_LINK (AND_LINK ($context $action)) $goal)) (IMPLICATION (AND_LINK ($context $action)) $goal))
+        (((IMPLICATION_LINK (AND_LINK ($context $action)) $goal) (TTV $timestamp $stv)) (IMPLICATION (AND_LINK ($context $action)) $goal))
+        (((IMPLICATION_LINK (AND_LINK ($context $action)) $goal)) (IMPLICATION (AND_LINK ($context $action)) $goal) )
+        ($_ %Undefined%)
+      )
+
+    )
+)
 
 ;(: x (Goal $value $dgv))
 (: addGoalHelper (-> Symbol Number Number Grounded Atom))

--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -6,19 +6,19 @@
 
 (= (PsiRules) &psiRules)
 
-(: addAndLink (-> Expression Action Expression))
-(= (addAndLink $context $action)
+(: addAndLink (-> Grounded Expression Expression Expression))
+(= (addAndLink $space $context $action)
    (let $res 
-        (collapse (match &self (AND_LINK ($context $action)) (AND_LINK ($context $action))))
+        (collapse (match  $space (AND_LINK ($context $action)) (AND_LINK ($context $action))))
         (if (not (== $res ()))
           (car-atom $res)
-          (let () (add-atom &self (AND_LINK ($context $action))) (AND_LINK ($context $action)))
+          (let () (add-atom  $space (AND_LINK ($context $action))) (AND_LINK ($context $action)))
         )
      )
 )
 
-;(: addRuleLink (-> Symbol Goal Expression Expression))
-(= (addRuleLink $handle $goal $andLink)
+(: addRuleLink (-> Grounded Symbol Expression Expression Expression))
+(= (addRuleLink  $space $handle $goal $andLink)
    (let*
      (
       ($rule (collapse (get-type $handle)))
@@ -28,9 +28,9 @@
             (
               let* (
                     ($newRule (: $handle (IMPLICATION_LINK $andLink $goal)))
-                    ($_ (add-atom &self $newRule))
-                    ($_ (add-atom &self (: $handle (TTV 0 (STV 0.0 0.0)))))
-                    ($_ (add-atom &self (isExecuted $handle (DEFAULT_TV)))) ;TODO: define DEFAULT_TV
+                    ($_ (add-atom  $space $newRule))
+                    ($_ (add-atom  $space (: $handle (TTV 0 (STV 0.0 0.0)))))
+                    ($_ (add-atom  $space (isExecuted $handle (DEFAULT_TV)))) ;TODO: define DEFAULT_TV
                   )
                   ()
             )
@@ -43,22 +43,23 @@
    ( let $res (collapse (get-type-space $space $atom)) (not (== (%Undefined%) $res)) )
 )
 
+(: addRule (-> Grounded Symbol Expression Expression Symbol Expression Expression))
 ;(: addRule (-> Symbol Expression Action Symbol Goal Expression))
-(= (addRule $ruleHandle $context $action $goal $tv)
+(= (addRule $space $ruleHandle $context $action $goal $tv)
     (let* (
-            ($andLink (addAndLink $context $action))
-            ($_ (addRuleLink $ruleHandle $goal $andLink))
+            ($andLink (addAndLink $space $context $action))
+            ($_ (addRuleLink   $space $ruleHandle $goal $andLink))
             ($exists (existsIn &psiRules $ruleHandle))
           )
           (if $exists 
               $ruleHandle
               (let* 
                 (
-                  ($res (getRuleType $ruleHandle &self))
+                  ($res (getRuleType $ruleHandle $space))
                   ($_ (if (== (len $res) 2) ; Important to avoid adding another $tv to $ruleHandle as type.
-                          (update-atom &self (: $ruleHandle (TTV 0 (STV 0.0 0.0))) (: $ruleHandle $tv)) 
+                          (update-atom $space (: $ruleHandle (TTV 0 (STV 0.0 0.0))) (: $ruleHandle $tv)) 
                           () ))
-                  ($_ (update-atom &self (isExecuted $ruleHandle (DEFAULT_TV)) (isExecuted $ruleHandle (FALSE_TV))))
+                  ($_ (update-atom $space (isExecuted $ruleHandle (DEFAULT_TV)) (isExecuted $ruleHandle (FALSE_TV))))
                 )
                 (let () (if (== (len $context) 1)
                     (add-atom &psiRules (: $ruleHandle ($context $action $goal (car-atom $context))))
@@ -71,10 +72,10 @@
     )
 )
  
-(: getAction (-> Symbol Expression))
-(= (getAction $rule) 
+(: getAction (-> Grounded Symbol Expression))
+(= (getAction $space $rule) 
    (
-    case (getRuleType $rule &self) 
+    case (getRuleType $rule $space) 
       (
         (((TTV $timestamp $stv) (IMPLICATION_LINK (AND_LINK ($context $action)) $goal)) $action)
         (((IMPLICATION_LINK (AND_LINK ($context $action)) $goal) (TTV $timestamp $stv)) $action)
@@ -84,10 +85,10 @@
    )
 )
 
-;(: getGoal (-> Symbol Expression))
-(= (getGoal $rule)  
+(: getGoal (-> Grounded Symbol Expression))
+(= (getGoal $space $rule)  
   ( 
-   case (getRuleType $rule &self) 
+   case (getRuleType $rule $space) 
     (
       (((TTV $timestamp $stv) (IMPLICATION_LINK $andLink $goal)) $goal)
       (((IMPLICATION_LINK $andLink $goal) (TTV $timestamp $stv)) $goal)
@@ -97,10 +98,10 @@
    )
 )
 
-(: getContext (-> Symbol Expression))
-(= (getContext $rule)
+(: getContext (-> Grounded Symbol Expression))
+(= (getContext $space $rule)
    (
-    case (getRuleType $rule &self) 
+    case (getRuleType $rule $space) 
       (
         (((TTV $timestamp $stv) (IMPLICATION_LINK (AND_LINK ($context $action)) $goal)) $context)
         (((IMPLICATION_LINK (AND_LINK ($context $action)) $goal) (TTV $timestamp $stv)) $context)
@@ -182,14 +183,14 @@
 ;arg2: an accumulator
 ;return: a tuple of valid psiRules
 
-(= (filterPsiRules $andLinks $acc)
+(= (filterPsiRules $space $andLinks $acc)
    (if (== $andLinks ())
       $acc
       (let* (
               (($head $tail) (decons-atom $andLinks))
-              ($handles (collapse (match &self (: $handle (IMPLICATION_LINK $head $goal)) $handle)))
+              ($handles (collapse (match $space (: $handle (IMPLICATION_LINK $head $goal)) $handle)))
               ($rulesList (concatTuple $handles $acc))
-              ($res (filterPsiRules $tail $rulesList))
+              ($res (filterPsiRules $space $tail $rulesList))
             )
         (if (== $head ())
           $acc
@@ -207,11 +208,11 @@
 ;arg: action
 ;returns: a tuple of goals
 
-(= (relatedGoals $action)
+(= (relatedGoals $space $action)
    (let* (
-          ($andLinks (collapse (match &self (AND_LINK ($context $action)) (AND_LINK ($context $action)))))
-          ($rules (filterPsiRules $andLinks ()))
-          ($goals (collapse (getGoal (superpose $rules))))
+          ($andLinks (collapse (match $space (AND_LINK ($context $action)) (AND_LINK ($context $action)))))
+          ($rules (filterPsiRules $space $andLinks ()))
+          ($goals (collapse (getGoal $space (superpose $rules))))
           ($res (collapse (unique (superpose $goals)))) ; remove duplicate goals
         )
         $res

--- a/main/rules/tests/rule-test.metta
+++ b/main/rules/tests/rule-test.metta
@@ -22,10 +22,9 @@
 !(assertEqual (getAction  &r x) y)
 !(assertEqual (getGoal  &r x) z)
 !(assertEqual (getTV x &r) (TTV 1 (STV 1.0 1.0)))
-
+!(assertEqual (getImplication x &r) (IMPLICATION (AND_LINK ((x1 x2) y)) z))
 
 !(addRule  &r w (x3 x2) y z (TTV 1 (STV 1.0 1.0)))
-
 ; ;if rule is not added with the addRule function then the &psiRules index does not know
 ; about it
 ; but we can get context, action and goal of the rule
@@ -36,6 +35,7 @@
 !(assertEqual (getContext &r rule1) (c1 c2))
 !(assertEqual (getGoal &r rule1) goal)
 !(assertEqual (getAction &r rule1) action)
+!(assertEqual (getImplication rule1 &r) (IMPLICATION (AND_LINK ((c1 c2) action)) goal))
 
 
 !(assertEqual (existsIn &psiRules rule1) False)

--- a/main/rules/tests/rule-test.metta
+++ b/main/rules/tests/rule-test.metta
@@ -5,33 +5,38 @@
 !(import! &self hyperon-openpsi:main:types)
 !(import! &self utilities-module:utils)
 
-!(assertEqual (addAndLink (a b) c) (AND_LINK ((a b) c)))
+!(bind! &r (new-space)) 
 
-;add the same AND_LINK the second time, it should not be added again. It should 
-;return the Already existing AND_LINK.
-!(assertEqual (addAndLink (a b) c) (AND_LINK ((a b) c)))
+!(assertEqual (addAndLink &r (a b) c) (AND_LINK ((a b) c)))
+
+; add the same AND_LINK the second time, it should not be added again. It should 
+; return the Already existing AND_LINK.
+!(assertEqual (addAndLink &r (a b) c) (AND_LINK ((a b) c)))
 
 ;if rule is added with the addRule function then the &psiRules index knows 
 ;about it
-(: z Goal)
-(: y Action)
 
-!(addRule x (x1 x2) y z (TTV 1 (STV 11.0 11.0)))
-!(assertEqual (getContext x) (x1 x2))
-!(assertEqual (getAction x) y)
-!(assertEqual (getGoal x) z)
-!(assertEqual (getTV x &self) (TTV 1 (STV 11.0 11.0)))
 
-!(addRule x (x1 x2) y z (TTV 1 (STV 11.0 11.0)))
+!(addRule  &r x (x1 x2) y z (TTV 1 (STV 1.0 1.0)))
+!(assertEqual (getContext  &r x) (x1 x2))
+!(assertEqual (getAction  &r x) y)
+!(assertEqual (getGoal  &r x) z)
+!(assertEqual (getTV x &r) (TTV 1 (STV 1.0 1.0)))
 
-;if rule is not added with the addRule function then the &psiRules index does not 
-;know about it
-!(add-atom &self (: rule1 (IMPLICATION_LINK 
-                            (AND_LINK (c1 c2) action)
-                            goal)))
-!(assertEqual (getContext rule1) %Undefined%)
-!(assertEqual (getGoal rule1) %Undefined%)
-!(assertEqual (getAction rule1) %Undefined%)
+
+!(addRule  &r w (x3 x2) y z (TTV 1 (STV 1.0 1.0)))
+
+; ;if rule is not added with the addRule function then the &psiRules index does not know
+; about it
+; but we can get context, action and goal of the rule
+
+!(add-atom &r (: rule1 (IMPLICATION_LINK 
+                            (AND_LINK ((c1 c2) action))
+                            goal )))
+!(assertEqual (getContext &r rule1) (c1 c2))
+!(assertEqual (getGoal &r rule1) goal)
+!(assertEqual (getAction &r rule1) action)
+
 
 !(assertEqual (existsIn &psiRules rule1) False)
 
@@ -44,8 +49,7 @@
 !(assertEqual (addGoal run 1 () &self) run)
 
 
-!(assertEqual (relatedGoals y) (z))
-
+!(assertEqual (relatedGoals &r y) (z))
 
 ;Category tests
 !(assertEqual (addCategory testI) testI)


### PR DESCRIPTION
### Key Changes
- Updated  `addRule` , `addRuleLink` and `addAndLink`  with space argument instead of &self
- Updated `addRule` with  type: `(: addRule (-> Grounded Symbol Expression Expression Symbol Expression Expression))`
-  Updated `addRuleLink` with  type: `(: addRuleLink (-> Grounded Symbol Expression Expression Expression))`
- Updated `addAndLink`  with  type: `(: addAndLink (-> Grounded Expression Expression Expression))`
- Refactored dependent functions :
  - `getContext`
  - `getGoal`
  - `getAction`
  - `filterPsiRules `
  - `relatedGoals `
- Updated test cases in `rule-test.metta` 
- Updated  `hillClimbingPlanner`, `addRule` & `addGoal` with space argument in `action-planner-v2-test.metta`
- Implement `getImplication` function with type: `(: getImplication (-> Symbol Grounded Expression))`
- Add test case for `getImplication` function

