### PR TITLE
Ping Pong use-case

### DIFF
--- a/main/rules/rule.metta
+++ b/main/rules/rule.metta
@@ -319,6 +319,34 @@
     (== (STV 1 1)  ($satisfiableChecker $rule))
 )
 
+
+; urge related functions 
+(: urge-value (-> Symbol Grounded Number))
+(=(urge-value $goal $space)
+  (- (desired-goal-value $goal $space) (goal-value $goal $space))
+ )
+
+
+(= (increase-urge $goal $value $space)
+  (let*
+      (
+        ($urge (urge-value $goal $space))
+        ($u (- 1.0 (+ $urge $value)))
+      )
+     (setGv $goal $u $space)
+  )
+)
+
+(= (decrease-urge $goal $value $space)
+  (let*
+      (
+        ($urge (urge-value $goal $space))
+        ($u (- 1.0 (- $urge $value)))
+      )
+     (setGv $goal $u $space)
+  )
+)
+
 ;; (= (checkSatisfiability))
 ;; !(foldl * 1 (1 2 3 4 5))
 ;; !(foldl min 1 (1 2 3 4 5))

--- a/main/rules/tests/rule-test.metta
+++ b/main/rules/tests/rule-test.metta
@@ -62,3 +62,17 @@
 !(assertEqual (contextStv ((STV 1 1) (STV 1 1))) (STV 1.0 1.0))
 !(assertEqual (contextStv ((STV 0 0) (STV 0 0))) (STV 0 0))
 
+;urge Tests 
+
+!(addGoal (pinged) 0.75 1.0 &self)
+!(assertEqual (goal-value  (pinged) &self) 0.75)
+!(assertEqual (urge-value  (pinged) &self) 0.25)
+
+!(increase-urge (pinged) 0.15 &self)
+!(assertEqual (urge-value  (pinged) &self) 0.4)
+!(increase-urge (pinged) 0.3 &self)
+!(assertEqual (urge-value  (pinged) &self) 0.7)
+
+!(decrease-urge (pinged) 0.45 &self)
+!(assertEqual (urge-value  (pinged) &self) 0.25)
+

--- a/use-cases/ping-pong/ping-pong.metta
+++ b/use-cases/ping-pong/ping-pong.metta
@@ -57,6 +57,11 @@
     )
 )
 
+(=(reverse $list $acc)  
+    (if(== $list ()) $acc
+    (let ($head $tail ) (decons-atom $list) (reverse $tail (cons-atom $head $acc) ))
+    )
+)
 
 !(addGoal (ball is neutral) 0.0 1.0 &r)
 !(addGoal (ball is pinged) 0.0 1.0 &r)
@@ -86,7 +91,7 @@
 !(addRule &r r3 ((ball is ponged))  (quote (ping)) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
 
 
-!(planner: (hillClimbingPlanner  (ball is neutral) (ball is ponged) (TestedActions) () &r))
+!(let $planner (hillClimbingPlanner  (ball is neutral) (ball is ponged) (TestedActions) () &r) (reverse $planner ()))
 
 
 ; to see the actions step

--- a/use-cases/ping-pong/ping-pong.metta
+++ b/use-cases/ping-pong/ping-pong.metta
@@ -62,10 +62,10 @@
 !(addGoal (ball is pinged) 0.0 1.0 &r)
 !(addGoal (ball is ponged) 1.0 1.0 &r)
 
-!(addRule &r r1 ((ball is neutral)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
-!(addRule &r r2 ((ball is pinged)) (pong-step-loop) (ball is ponged) (TTV 0 (STV 1.0 1.0)))
-!(addRule &r r3 ((ball is ponged)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
-
+;; One cycle 
+; !(addRule &r r1 ((ball is neutral)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
+; !(addRule &r r2 ((ball is pinged)) (pong-step-loop) (ball is ponged) (TTV 0 (STV 1.0 1.0)))
+; !(addRule &r r3 ((ball is ponged)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
 
 ; to continously play ping pong
 ; (= (loop)
@@ -80,4 +80,16 @@
 
 ; !(loop)
 
-; !(ping-pong use-case experiment)
+; qoute the actions for the plannerAdd commentMore actions
+!(addRule &r r1 ((ball is neutral))  (quote (ping)) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r2 ((ball is pinged))  (quote (pong-step-loop)) (ball is ponged) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r3 ((ball is ponged))  (quote (ping)) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
+
+
+!(planner: (hillClimbingPlanner  (ball is neutral) (ball is ponged) (TestedActions) () &r))
+
+
+; to see the actions step
+!(ping)
+!(pong-step-loop)
+

--- a/use-cases/ping-pong/ping-pong.metta
+++ b/use-cases/ping-pong/ping-pong.metta
@@ -1,2 +1,83 @@
-!(ping-pong use-case experiment)
+!(register-module! ../../../hyperon-openpsi)
+!(register-module! ../../utilities-module)
 
+!(import! &self hyperon-openpsi:main:mind-agents:action-planner:action-planner-v2)
+!(import! &self hyperon-openpsi:main:types)
+!(import! &self hyperon-openpsi:main:rules:rule)
+!(import! &self utilities-module:utils)
+
+!(bind! &r (new-space)) 
+!(bind! sleep (py-atom time.sleep))
+
+
+(= (ping) (let $t (sleep 1)  (println! (Just ball is pinged))))
+
+(= (pong) 
+    (let*
+    
+        (
+            ($t (sleep 1))
+            ($du (decrease-urge (ball is ponged) 1 &r))
+        ) 
+            (println! (Just ball is ponged))
+    )
+)
+
+(= (pong-step) 
+    (let*
+    
+        (
+            ($t (sleep 1))
+            ($urge (urge-value (ball is ponged) &r))
+        ) 
+
+        (if (< $urge 0.7)
+            (let $p (println! (Not yet feeling like ponging the ball. Urge = $urge))
+            (increase-urge (ball is ponged) 0.2 &r))
+            
+            (let* 
+                (
+                ($p (println! (Feeling like ponging the ball. Urge = $urge)))
+                ($inc (increase-urge (ball is ponged) 0.2 &r))
+                )
+                (pong)
+                
+            )
+        )
+    )
+)
+
+(= (pong-step-loop)
+    (let $urge (urge-value (ball is ponged) &r)
+        
+        (if (< $urge 0.7)
+            (let $ps (pong-step) (pong-step-loop)) ; recursively call until urge >= 0.7
+            (pong-step) ;  call to trigger pong when urge >= 0.7
+        )
+    )
+)
+
+
+!(addGoal (ball is neutral) 0.0 1.0 &r)
+!(addGoal (ball is pinged) 0.0 1.0 &r)
+!(addGoal (ball is ponged) 1.0 1.0 &r)
+
+!(addRule &r r1 ((ball is neutral)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r2 ((ball is pinged)) (pong-step-loop) (ball is ponged) (TTV 0 (STV 1.0 1.0)))
+!(addRule &r r3 ((ball is ponged)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0)))
+
+
+; to continously play ping pong
+; (= (loop)
+;     (let*
+;     (
+;        ($r1 (addRule &r r1 ((ball is neutral)) (ping) (ball is pinged) (TTV 0 (STV 1.0 1.0))))
+;        ($r2 (addRule &r r2 ((ball is pinged)) (pong-step-loop) (ball is ponged) (TTV 0 (STV 1.0 1.0))))
+;     )
+;         (loop)
+;     )
+; )
+
+; !(loop)
+
+; !(ping-pong use-case experiment)


### PR DESCRIPTION
### Ping Pong use case Description 

Based on opencog examples in openpsi

- we have three contexts/goals -  (ball is neutral),  (ball is pinged),  (ball is ponged)
- we have two actions - ping , pong-step-loop
- ping action just prints (Just ball is pinged) after a second
- pong-step-loop loop through pong-step and update the urge value till urge value of pong goal become above 0.7 and prints (Just ball is ponged). 
- the hillClimbingPlanner outputs the planned actions  with order. 
