### PR TITLE
fix: restructured test files adding test space definitions.

### DIFF
--- a/main/feed-back-loop/test/feedback-loop-test.metta
+++ b/main/feed-back-loop/test/feedback-loop-test.metta
@@ -15,6 +15,64 @@
 !(bind! &modulator-space (new-space))
 !(bind! &demandspace (new-space))
 
+(= (addRulesToTestSpace $space)
+    (add-reduct $space (superpose     
+        
+    (
+            
+        ((: r1 ((TTV 1 (STV 0.8 0.7)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal init 0.9 0.6) explore)) 
+          (Goal found_target 1.0 1.0)))) 2)
+
+;; r2: Approach after finding target
+((: r2 ((TTV 1 (STV 0.75 0.65)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal found_target 1.0 1.0) approach)) 
+          (Goal near_target 1.0 1.0)))) 3)
+
+;; r3: Interact when near
+((: r3 ((TTV 1 (STV 0.7 0.6)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal near_target 1.0 1.0) interact)) 
+          (Goal task_done 1.0 1.0)))) 2)
+
+;; r4: Report task done
+((: r4 ((TTV 1 (STV 0.65 0.6)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal task_done 1.0 1.0) report)) 
+          (Goal mission_complete 1.0 1.0)))) 10)
+
+;; r5: Do nothing and become low energy
+((: r5 ((TTV 1 (STV 0.5 0.5)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal init 0.8 0.5) idle)) 
+          (Goal low_energy 1.0 1.0)))) 1)
+
+;; r6: Analyze after mission complete
+((: r6 ((TTV 1 (STV 0.75 0.7)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal mission_complete 0.9 0.7) analyze)) 
+          (Goal analyze_data 1.0 1.0)))) 4)
+
+;; r7: Upload results after analysis
+((: r7 ((TTV 1 (STV 0.7 0.7)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal analyze_data 0.85 0.7) upload)) 
+          (Goal upload_results 1.0 1.0)))) 2)
+
+;; r8: Reboot after upload
+((: r8 ((TTV 1 (STV 0.9 0.8)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal upload_results 0.95 0.75) reboot)) 
+          (Goal reset_system 1.0 1.0)))) 1)
+
+    )
+        )
+    )
+
+)
+
 !(addRulesToTestSpace &ruleSpace) 
 !(insert-modulators &modulator-space)
 

--- a/main/mind-agents/action-planner/action-planner-v1.metta
+++ b/main/mind-agents/action-planner/action-planner-v1.metta
@@ -11,63 +11,6 @@
 ;; 7. Then it starts from the goal as a context from the rule that is selected.
 !(bind! &ruleSpace (new-space))
 
-(= (addRulesToTestSpace $space)
-    (add-reduct $space (superpose     
-        
-    (
-            
-        ((: r1 ((TTV 1 (STV 0.8 0.7)) 
-            (IMPLICATION_LINK 
-          (AND_LINK ((Goal init 0.9 0.6) explore)) 
-          (Goal found_target 1.0 1.0)))) 2)
-
-;; r2: Approach after finding target
-((: r2 ((TTV 1 (STV 0.75 0.65)) 
-        (IMPLICATION_LINK 
-          (AND_LINK ((Goal found_target 1.0 1.0) approach)) 
-          (Goal near_target 1.0 1.0)))) 3)
-
-;; r3: Interact when near
-((: r3 ((TTV 1 (STV 0.7 0.6)) 
-        (IMPLICATION_LINK 
-          (AND_LINK ((Goal near_target 1.0 1.0) interact)) 
-          (Goal task_done 1.0 1.0)))) 2)
-
-;; r4: Report task done
-((: r4 ((TTV 1 (STV 0.65 0.6)) 
-        (IMPLICATION_LINK 
-          (AND_LINK ((Goal task_done 1.0 1.0) report)) 
-          (Goal mission_complete 1.0 1.0)))) 10)
-
-;; r5: Do nothing and become low energy
-((: r5 ((TTV 1 (STV 0.5 0.5)) 
-        (IMPLICATION_LINK 
-          (AND_LINK ((Goal init 0.8 0.5) idle)) 
-          (Goal low_energy 1.0 1.0)))) 1)
-
-;; r6: Analyze after mission complete
-((: r6 ((TTV 1 (STV 0.75 0.7)) 
-            (IMPLICATION_LINK 
-          (AND_LINK ((Goal mission_complete 0.9 0.7) analyze)) 
-          (Goal analyze_data 1.0 1.0)))) 4)
-
-;; r7: Upload results after analysis
-((: r7 ((TTV 1 (STV 0.7 0.7)) 
-            (IMPLICATION_LINK 
-          (AND_LINK ((Goal analyze_data 0.85 0.7) upload)) 
-          (Goal upload_results 1.0 1.0)))) 2)
-
-;; r8: Reboot after upload
-((: r8 ((TTV 1 (STV 0.9 0.8)) 
-            (IMPLICATION_LINK 
-          (AND_LINK ((Goal upload_results 0.95 0.75) reboot)) 
-          (Goal reset_system 1.0 1.0)))) 1)
-
-    )
-        )
-    )
-
-)
 
 (= (addRulesToSpace $space)
     (add-reduct $space ( superpose 

--- a/main/mind-agents/action-planner/tests/action-planner-v1-test.metta
+++ b/main/mind-agents/action-planner/tests/action-planner-v1-test.metta
@@ -1,6 +1,66 @@
 !(register-module! ../../../../../hyperon-openpsi)
 !(import! &self hyperon-openpsi:main:mind-agents:action-planner:action-planner-v1)
+
 !(bind! &testSpace (new-space))
+!(bind! &RuleSpace (new-space))
+
+(= (addRulesToTestSpace $space)
+    (add-reduct $space (superpose     
+        
+    (
+            
+        ((: r1 ((TTV 1 (STV 0.8 0.7)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal init 0.9 0.6) explore)) 
+          (Goal found_target 1.0 1.0)))) 2)
+
+;; r2: Approach after finding target
+((: r2 ((TTV 1 (STV 0.75 0.65)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal found_target 1.0 1.0) approach)) 
+          (Goal near_target 1.0 1.0)))) 3)
+
+;; r3: Interact when near
+((: r3 ((TTV 1 (STV 0.7 0.6)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal near_target 1.0 1.0) interact)) 
+          (Goal task_done 1.0 1.0)))) 2)
+
+;; r4: Report task done
+((: r4 ((TTV 1 (STV 0.65 0.6)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal task_done 1.0 1.0) report)) 
+          (Goal mission_complete 1.0 1.0)))) 10)
+
+;; r5: Do nothing and become low energy
+((: r5 ((TTV 1 (STV 0.5 0.5)) 
+        (IMPLICATION_LINK 
+          (AND_LINK ((Goal init 0.8 0.5) idle)) 
+          (Goal low_energy 1.0 1.0)))) 1)
+
+;; r6: Analyze after mission complete
+((: r6 ((TTV 1 (STV 0.75 0.7)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal mission_complete 0.9 0.7) analyze)) 
+          (Goal analyze_data 1.0 1.0)))) 4)
+
+;; r7: Upload results after analysis
+((: r7 ((TTV 1 (STV 0.7 0.7)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal analyze_data 0.85 0.7) upload)) 
+          (Goal upload_results 1.0 1.0)))) 2)
+
+;; r8: Reboot after upload
+((: r8 ((TTV 1 (STV 0.9 0.8)) 
+            (IMPLICATION_LINK 
+          (AND_LINK ((Goal upload_results 0.95 0.75) reboot)) 
+          (Goal reset_system 1.0 1.0)))) 1)
+
+    )
+        )
+    )
+
+)
 (= (addRules $space) 
     (add-reduct $space (superpose (
     ;; r1: Explore when initialized
@@ -245,7 +305,7 @@
 ))))
 
 
-!(addRulesToTestSpace &ruleSpace)
+!(addRulesToTestSpace &RuleSpace)
 !(addRules &testSpace)
 
 !(assertEqual (getWeightFromRule ((: r1 ((TTV 1 (STV 0.8 0.7)) 
@@ -256,15 +316,15 @@
                     (IMPLICATION_LINK 
                     (AND_LINK ((Goal init 0.9 0.6) explore)) 
                     (Goal found_target 1.0 1.0)))) 3)) 3)
-!(assertEqual (selectSingleAction &ruleSpace (()) 1.0) (() ()))
+!(assertEqual (selectSingleAction &RuleSpace (()) 1.0) (() ()))
 !(assertEqual (selectActionFromRule ((: r1 ((TTV 1 (STV 0.8 0.7)) 
                     (IMPLICATION_LINK 
                     (AND_LINK ((Goal init 0.9 0.6) explore)) 
                     (Goal found_target 1.0 1.0)))) 2)) explore)
-!(addRules &testSpace)
-!(assertEqual (selectSingleAction &ruleSpace (collapse (get-atoms &ruleSpace)) 10) (((: r4 ((TTV 1 (STV 0.65 0.6)) (IMPLICATION_LINK (AND_LINK ((Goal task_done 1 1) report)) (Goal mission_complete 1 1)))) 10) report))
-!(assertEqual (findRulesWithGoalAsContext &ruleSpace low_energy) ())
-!(assertEqual (findRulesWithGoalAsContext &ruleSpace found_target) (((: r2 ((TTV 1 (STV 0.75 0.65)) (IMPLICATION_LINK (AND_LINK ((Goal found_target 1 1) approach)) (Goal near_target 1 1)))) 3)))
-!(assertEqual (planner &ruleSpace init  mission_complete) (explore approach interact report))
+
+!(assertEqual (selectSingleAction &RuleSpace (collapse (get-atoms &RuleSpace)) 10) (((: r4 ((TTV 1 (STV 0.65 0.6)) (IMPLICATION_LINK (AND_LINK ((Goal task_done 1 1) report)) (Goal mission_complete 1 1)))) 10) report))
+!(assertEqual (findRulesWithGoalAsContext &RuleSpace low_energy) ())
+!(assertEqual (findRulesWithGoalAsContext &RuleSpace found_target) (((: r2 ((TTV 1 (STV 0.75 0.65)) (IMPLICATION_LINK (AND_LINK ((Goal found_target 1 1) approach)) (Goal near_target 1 1)))) 3)))
+!(assertEqual (planner &RuleSpace init  mission_complete) (explore approach interact report))
 
 !(assertEqual (planner &testSpace init model_deployed) (explore recharge shutdown wake init_sensors train predict validate save deploy))

--- a/main/mind-agents/action-planner/tests/action-planner-v2-test.metta
+++ b/main/mind-agents/action-planner/tests/action-planner-v2-test.metta
@@ -65,6 +65,6 @@
 
 !(addRulesToSpace &ruleSpace)
 
-!(get-atoms &ruleSpace)
+;!(get-atoms &ruleSpace)
 ;!(assertEqual (hillClimbingPlanner init mission_complete (TestedActions) () &ruleSpace) (explore approach interact report))
 ;!(assertEqual (hillClimbingPlanner init task_done (TestedActions) () &ruleSpace) (explore approach interact))

--- a/main/mind-agents/modulator-updater/tests/modulator-updaters-test.metta
+++ b/main/mind-agents/modulator-updater/tests/modulator-updaters-test.metta
@@ -1,13 +1,16 @@
 !(register-module! ../../../../../hyperon-openpsi)
 !(import! &self hyperon-openpsi:main:modulator:modulator)
 !(import! &self hyperon-openpsi:main:mind-agents:modulator-updater:modulator-updaters)
-!(import! &self hyperon-openpsi:main:feed-back-loop:feed-back-loop)
 !(import! &self hyperon-openpsi:main:mind-agents:modulator-updater:tests:modulator-updater-test-helpers)
+
 !(register-module! ../../../../utilities-module)
 !(import! &self utilities-module:utils)
 !(import! &self hyperon-openpsi:psi-utilities:psi_utils)
 !(import! &self hyperon-openpsi:main:demand:demand)
 !(import! &self hyperon-openpsi:psi-utilities:normalization)
+
+!(bind! &demandspace (new-space))
+!(bind! &modulator-space (new-space))
 
 !(addDemand &demandspace energy 0.6)
 !(addDemand &demandspace affiliation 0.5)


### PR DESCRIPTION
This PR introduces the following changes:
- Define testing spaces for modulator-updaters-test.metta.
- Define a testing space for action-planner-v1-test.metta to make it more logically structured.
- Moved addRulesToTestSpace function definition to its referencing test-case file.