### PR TITLE
fix: removed repository cloning in installation script

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e  
 
-VENV_DIR=".venv"
+VENV_DIR="venv"
 if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtual environmnet..."
+    echo "Creating virtual environment..."
     python3 -m venv "$VENV_DIR"
 fi
 
-echo "Activating virtual environmnent..."
+echo "Activating virtual environment..."
 source "$VENV_DIR/bin/activate"
 
 # === Step 1: Upgrade pip to required version ===
@@ -21,20 +21,8 @@ pip install numpy==2.2.1
 echo "Installing hyperon==0.2.3..."
 python3 -m pip install hyperon==0.2.3
 
-# === Step 3: Clone the GitHub repo ===
-REPO_URL="https://github.com/iCog-Labs-Dev/hyperon-openpsi.git"
-TARGET_DIR="hyperon-openpsi"
-
-if [ ! -d "$TARGET_DIR" ]; then
-    echo "Cloning repository..."
-    git clone "$REPO_URL" "$TARGET_DIR"
-else
-    echo "Repository already exists, skipping clone."
-fi
-
-# === Step 4: Initialize submodules ===
+# === Step 3: Initialize submodules ===
 echo "Updating submodules..."
-cd "$TARGET_DIR"
 git submodule update --init --recursive
 
 echo "Setup complete!"


### PR DESCRIPTION
Summary

* Removed the repository cloning step, as the repository is assumed to be cloned by the user beforehand.
* Renamed the Python virtual environment directory from .venv to venv for consistency and to align with the existing .gitignore configuration.